### PR TITLE
Harmonise versions with StrIoT 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,30 +1,202 @@
-Copyright Jonny Spruce (c) 2020
 
-All rights reserved.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
+   1. Definitions.
 
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-    * Neither the name of Author name here nor the names of other
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/package.yaml
+++ b/package.yaml
@@ -47,4 +47,4 @@ tests:
       - -with-rtsopts=-N
     dependencies:
       - striot-gui
-      - hspec >=2.7.1
+      - hspec >=2.6.1

--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,50 @@
+name: striot-gui
+version: 0.1.0.0
+github: "JonnySpruce/striot-gui"
+license: Apache
+author: "Jonny Spruce"
+maintainer: "jspruce94@gmail.com"
+copyright: "2020 Jonny Spruce"
+
+extra-source-files:
+  - README.md
+  - ChangeLog.md
+
+# Metadata used when publishing your package
+# synopsis:            Short description of your package
+# category:            Web
+
+description: Please see the README on GitHub at <https://github.com/jonnyspruce/striot-gui#readme>
+
+dependencies:
+  - aeson >=1.4.6.0
+  - algebraic-graphs >=0.1
+  - base >= 4.9
+  - bytestring >= 0.9.2
+  - striot >=0.1.0.4
+
+library:
+  source-dirs: src
+
+executables:
+  striot-gui-exe:
+    main: Main.hs
+    source-dirs: app
+    ghc-options:
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
+    dependencies:
+      - striot-gui
+
+tests:
+  striot-gui-test:
+    main: Spec.hs
+    source-dirs: test
+    ghc-options:
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
+    dependencies:
+      - striot-gui
+      - hspec >=2.7.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,8 +11,6 @@ extra-deps:
   - network-3.1.0.0
   - prometheus-2.1.2
   - socks-0.6.1
-  - store-0.7.2
-  - store-core-0.4.4.2
   - store-streaming-0.1.0.0
   - th-utilities-0.2.3.1
   - time-compat-1.9.2.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,12 @@ extra-deps:
   - git: https://github.com/striot/striot.git
     commit: 1441100588615723481b9d7571dbb5b37bbd65d4
   - aeson-1.4.6.0
-  - hspec-2.7.1
+  - network-3.1.0.0
+  - unagi-chan-0.4.1.0
+  - time-compat-1.9.2.2
+  - websockets-0.12.6.1
+  - connection-0.3.1
+  - socks-0.6.1
   - hw-kafka-client-3.0.0
   - net-mqtt-0.6.2.3
   - prometheus-2.1.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,20 +1,20 @@
-resolver: lts-15.1
+resolver: lts-13.25
 packages:
   - .
 extra-deps:
   - git: https://github.com/striot/striot.git
     commit: 1441100588615723481b9d7571dbb5b37bbd65d4
   - aeson-1.4.6.0
-  - network-3.1.0.0
-  - unagi-chan-0.4.1.0
-  - time-compat-1.9.2.2
-  - websockets-0.12.6.1
   - connection-0.3.1
-  - socks-0.6.1
   - hw-kafka-client-3.0.0
-  - net-mqtt-0.6.2.3
-  - prometheus-2.1.3
+  - net-mqtt-0.6.2.1
+  - network-3.1.0.0
+  - prometheus-2.1.2
+  - socks-0.6.1
   - store-0.7.2
   - store-core-0.4.4.2
-  - store-streaming-0.2.0.0
+  - store-streaming-0.1.0.0
   - th-utilities-0.2.3.1
+  - time-compat-1.9.2.2
+  - unagi-chan-0.4.1.0
+  - websockets-0.12.6.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,15 +4,12 @@ packages:
 extra-deps:
   - git: https://github.com/striot/striot.git
     commit: 1441100588615723481b9d7571dbb5b37bbd65d4
-  - algebraic-graphs-0.5
   - aeson-1.4.6.0
-  - bytestring-0.10.10.0
   - hspec-2.7.1
-  - QuickCheck-2.13.2
-  - hw-kafka-client-3.0.0@sha256:a4757287b765de252f5f183e003eaf63c2c0acda051bdd72fd3f8610ca1f3cee,3172
-  - net-mqtt-0.6.2.3@sha256:3c2201ad7021a07bccd8bb0c64a8450451085ddd03178f2a916e7951d4e7260a,4131
-  - prometheus-2.1.3@sha256:4fdf8602f7c74367cda182cf71dab108f78a86993b428bf96b61dd6c519b6f22,4296
-  - store-0.7.2@sha256:94ca07b2af0ee15ee9e71f1576ea630676c3c016788c3dcb19d33d2998c3c228,7825
-  - store-streaming-0.2.0.0@sha256:f1194a9276362691f2ccc92473f4ebc9e7f7e57131e8f7c20c7c2e4eb264eb70,2006
-  - store-core-0.4.4.2@sha256:11403cad88cf4f3675d49baf76cb5dd56363e786c7e25ef00fa57296af29a7b2,1444
-  - th-utilities-0.2.3.1@sha256:40ebb0bc9569b4ff5c3be93c58a1e2a35e308a7e3effc73f6b324980f53f73fc,1869
+  - hw-kafka-client-3.0.0
+  - net-mqtt-0.6.2.3
+  - prometheus-2.1.3
+  - store-0.7.2
+  - store-core-0.4.4.2
+  - store-streaming-0.2.0.0
+  - th-utilities-0.2.3.1

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -68,20 +68,6 @@ packages:
   original:
     hackage: socks-0.6.1
 - completed:
-    hackage: store-0.7.2@sha256:94ca07b2af0ee15ee9e71f1576ea630676c3c016788c3dcb19d33d2998c3c228,7825
-    pantry-tree:
-      size: 1292
-      sha256: 9cfa13cb040285bf132085f3b75f31cdfad279fe7f31f05e5b20b2a2f9d85aca
-  original:
-    hackage: store-0.7.2
-- completed:
-    hackage: store-core-0.4.4.2@sha256:11403cad88cf4f3675d49baf76cb5dd56363e786c7e25ef00fa57296af29a7b2,1444
-    pantry-tree:
-      size: 271
-      sha256: 0db8705011f7f25d9e5f639c52ccce5fccb1de578de685def2b79e289d9de4cc
-  original:
-    hackage: store-core-0.4.4.2
-- completed:
     hackage: store-streaming-0.1.0.0@sha256:39d2c8b7960a90195c5f10e60334d1b10324aad01b3470fd8713b7acfdbf9cab,2009
     pantry-tree:
       size: 478

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -26,12 +26,12 @@ packages:
   original:
     hackage: aeson-1.4.6.0
 - completed:
-    hackage: hspec-2.7.1@sha256:0aa48928ce80a34f8ff8c5ef114bb6807edfb8d884bcd7211eceed710e7fb7a8,1769
+    hackage: connection-0.3.1@sha256:65da1c055610095733bcd228d85dff80804b23a5d18fede994a0f9fcd1b0c121,1554
     pantry-tree:
-      size: 532
-      sha256: 8128733a7ef4760bbe5d978f2145fdcb29f4491b17db11e8c05b409441ceecb4
+      size: 386
+      sha256: 13a2c21049e69068e4c3d725533d94729772f2d3e05f5ef611bef28363b08798
   original:
-    hackage: hspec-2.7.1
+    hackage: connection-0.3.1
 - completed:
     hackage: hw-kafka-client-3.0.0@sha256:a4757287b765de252f5f183e003eaf63c2c0acda051bdd72fd3f8610ca1f3cee,3172
     pantry-tree:
@@ -40,19 +40,33 @@ packages:
   original:
     hackage: hw-kafka-client-3.0.0
 - completed:
-    hackage: net-mqtt-0.6.2.3@sha256:3c2201ad7021a07bccd8bb0c64a8450451085ddd03178f2a916e7951d4e7260a,4131
+    hackage: net-mqtt-0.6.2.1@sha256:c1966caaa2b3894f7075450543dcd1f8017db14d06edb927a4f756533bd74398,4131
     pantry-tree:
       size: 700
-      sha256: d8baf796ada475bf15e145bcb316e4d6cd392308deed90be863c6ffc5b82047d
+      sha256: 702147709852ce98ef5bfe0374f3a1ad9f247ac4724151525ca36505dbe70eb3
   original:
-    hackage: net-mqtt-0.6.2.3
+    hackage: net-mqtt-0.6.2.1
 - completed:
-    hackage: prometheus-2.1.3@sha256:4fdf8602f7c74367cda182cf71dab108f78a86993b428bf96b61dd6c519b6f22,4296
+    hackage: network-3.1.0.0@sha256:85b36fea1dfe92af91b38224d6ea84eb0b17c03d9aed0260413be226722b0cd2,4074
+    pantry-tree:
+      size: 3296
+      sha256: 73580e0327c74a22776e1bfcc09aee25769b13de972a94a84a20f522596ebfed
+  original:
+    hackage: network-3.1.0.0
+- completed:
+    hackage: prometheus-2.1.2@sha256:dbd20f6003bd0b4602433b67ced7696322ec486143efc12b1d452dd312152224,3990
     pantry-tree:
       size: 1559
-      sha256: a8d0a0150abddf0d7b673fcb19ff2ef235d4005161826e1538ad802394c9fc0e
+      sha256: 1365a10d00c6c0e14a0c13de2fd281409dbc10416dd7fa74f22bfe4bf7bbfc60
   original:
-    hackage: prometheus-2.1.3
+    hackage: prometheus-2.1.2
+- completed:
+    hackage: socks-0.6.1@sha256:ac190808eea704672df18f702e8f2ad0b7a4d0af528e95ee55ea6ee0be672e2a,1258
+    pantry-tree:
+      size: 692
+      sha256: 53d29c06c42e737ae99660e077c7c4b286f1272b3394ad7f74163867a5b3b8fa
+  original:
+    hackage: socks-0.6.1
 - completed:
     hackage: store-0.7.2@sha256:94ca07b2af0ee15ee9e71f1576ea630676c3c016788c3dcb19d33d2998c3c228,7825
     pantry-tree:
@@ -68,12 +82,12 @@ packages:
   original:
     hackage: store-core-0.4.4.2
 - completed:
-    hackage: store-streaming-0.2.0.0@sha256:f1194a9276362691f2ccc92473f4ebc9e7f7e57131e8f7c20c7c2e4eb264eb70,2006
+    hackage: store-streaming-0.1.0.0@sha256:39d2c8b7960a90195c5f10e60334d1b10324aad01b3470fd8713b7acfdbf9cab,2009
     pantry-tree:
-      size: 479
-      sha256: 1a9236fe7b9d3172197c57d5b879dd15c51b4f825fd788688eafda75074c7ecc
+      size: 478
+      sha256: 171358012384b61ac1f29209898ffa7e2a6fa6d0c89efcb1be89a33b12cecc5e
   original:
-    hackage: store-streaming-0.2.0.0
+    hackage: store-streaming-0.1.0.0
 - completed:
     hackage: th-utilities-0.2.3.1@sha256:40ebb0bc9569b4ff5c3be93c58a1e2a35e308a7e3effc73f6b324980f53f73fc,1869
     pantry-tree:
@@ -81,9 +95,30 @@ packages:
       sha256: fa8f7a729bb497831a087af6368cc44a52bfdf058c54882a6f5513feb4d36212
   original:
     hackage: th-utilities-0.2.3.1
+- completed:
+    hackage: time-compat-1.9.2.2@sha256:ccf268e6ec91a6d9a79392697634c670c095a34a60d1ccfa1be1c84f20bb24c5,4254
+    pantry-tree:
+      size: 3602
+      sha256: f16cc56a43fa6047ad46b23770d5a16b9c400fd8d019e9b010b766a13e8eb588
+  original:
+    hackage: time-compat-1.9.2.2
+- completed:
+    hackage: unagi-chan-0.4.1.0@sha256:818559a286f2041135a92d504e5d6c55a3edf70e080a6d413912e0f1b705b82a,8893
+    pantry-tree:
+      size: 2286
+      sha256: 33e708a19c0d2a70923583924add3b1f71df61d3acdfabccc9511f2d3226bf5a
+  original:
+    hackage: unagi-chan-0.4.1.0
+- completed:
+    hackage: websockets-0.12.6.1@sha256:3816e841d8102877817d24ef5c96288e79f1323434268b866aa40732cc86763f,7649
+    pantry-tree:
+      size: 2592
+      sha256: 39a2bb7273c794e77bbc29cd1a0fa9ed15066bd27818cac88f3ab6d5d1d3220e
+  original:
+    hackage: websockets-0.12.6.1
 snapshots:
 - completed:
-    size: 489011
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/1.yaml
-    sha256: d4ecc42b7125d68e4c3c036a08046ad0cd02ae0d9efbe3af2223a00ff8cc16f3
-  original: lts-15.1
+    size: 499461
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/25.yaml
+    sha256: aed98969628e20615e96b06083c933c7e3354ae56b08b75e607a26569225d6c0
+  original: lts-13.25

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -19,26 +19,12 @@ packages:
     git: https://github.com/striot/striot.git
     commit: 1441100588615723481b9d7571dbb5b37bbd65d4
 - completed:
-    hackage: algebraic-graphs-0.5@sha256:6eeec5ed1687ff7aa916e7bf9f02f51aaabde6f314dc0b7b1a84156974d7da73,8071
-    pantry-tree:
-      size: 4128
-      sha256: cca4a0348bb126506cacd8436948a68aad62e75d45df8c71f4090a00e69b45ee
-  original:
-    hackage: algebraic-graphs-0.5
-- completed:
     hackage: aeson-1.4.6.0@sha256:560575b008a23960403a128331f0e59594786b5cd19a35be0cd74b9a7257958e,6980
     pantry-tree:
       size: 40193
       sha256: 5769473440ae594ae8679dde9fe12b6d00a49264a9dd8962a53ff3ae5740d7a5
   original:
     hackage: aeson-1.4.6.0
-- completed:
-    hackage: bytestring-0.10.10.0@sha256:06b2e84f1bc9ab71a162c0ca9e88358dd6bbe5cb7fdda2d6d34b6863c367ec95,8944
-    pantry-tree:
-      size: 2788
-      sha256: 0c8345618e3d7440989d5001ff57d01896548195338bf7a70d8453710a43418b
-  original:
-    hackage: bytestring-0.10.10.0
 - completed:
     hackage: hspec-2.7.1@sha256:0aa48928ce80a34f8ff8c5ef114bb6807edfb8d884bcd7211eceed710e7fb7a8,1769
     pantry-tree:
@@ -47,61 +33,54 @@ packages:
   original:
     hackage: hspec-2.7.1
 - completed:
-    hackage: QuickCheck-2.13.2@sha256:ad4e5adbd1c9dc0221a44307b992cb040c515f31095182e47aa7e974bc461df1,6952
-    pantry-tree:
-      size: 2202
-      sha256: f79eee2f6a00b2c649f993a7b358827702373cbc931ced55ebdfb59625540403
-  original:
-    hackage: QuickCheck-2.13.2
-- completed:
     hackage: hw-kafka-client-3.0.0@sha256:a4757287b765de252f5f183e003eaf63c2c0acda051bdd72fd3f8610ca1f3cee,3172
     pantry-tree:
       size: 2055
       sha256: e846e5d799beab5c83a91d6a9c93b54c9e86fc3a8eda9bd389216d44f5c9c809
   original:
-    hackage: hw-kafka-client-3.0.0@sha256:a4757287b765de252f5f183e003eaf63c2c0acda051bdd72fd3f8610ca1f3cee,3172
+    hackage: hw-kafka-client-3.0.0
 - completed:
     hackage: net-mqtt-0.6.2.3@sha256:3c2201ad7021a07bccd8bb0c64a8450451085ddd03178f2a916e7951d4e7260a,4131
     pantry-tree:
       size: 700
       sha256: d8baf796ada475bf15e145bcb316e4d6cd392308deed90be863c6ffc5b82047d
   original:
-    hackage: net-mqtt-0.6.2.3@sha256:3c2201ad7021a07bccd8bb0c64a8450451085ddd03178f2a916e7951d4e7260a,4131
+    hackage: net-mqtt-0.6.2.3
 - completed:
     hackage: prometheus-2.1.3@sha256:4fdf8602f7c74367cda182cf71dab108f78a86993b428bf96b61dd6c519b6f22,4296
     pantry-tree:
       size: 1559
       sha256: a8d0a0150abddf0d7b673fcb19ff2ef235d4005161826e1538ad802394c9fc0e
   original:
-    hackage: prometheus-2.1.3@sha256:4fdf8602f7c74367cda182cf71dab108f78a86993b428bf96b61dd6c519b6f22,4296
+    hackage: prometheus-2.1.3
 - completed:
     hackage: store-0.7.2@sha256:94ca07b2af0ee15ee9e71f1576ea630676c3c016788c3dcb19d33d2998c3c228,7825
     pantry-tree:
       size: 1292
       sha256: 9cfa13cb040285bf132085f3b75f31cdfad279fe7f31f05e5b20b2a2f9d85aca
   original:
-    hackage: store-0.7.2@sha256:94ca07b2af0ee15ee9e71f1576ea630676c3c016788c3dcb19d33d2998c3c228,7825
-- completed:
-    hackage: store-streaming-0.2.0.0@sha256:f1194a9276362691f2ccc92473f4ebc9e7f7e57131e8f7c20c7c2e4eb264eb70,2006
-    pantry-tree:
-      size: 479
-      sha256: 1a9236fe7b9d3172197c57d5b879dd15c51b4f825fd788688eafda75074c7ecc
-  original:
-    hackage: store-streaming-0.2.0.0@sha256:f1194a9276362691f2ccc92473f4ebc9e7f7e57131e8f7c20c7c2e4eb264eb70,2006
+    hackage: store-0.7.2
 - completed:
     hackage: store-core-0.4.4.2@sha256:11403cad88cf4f3675d49baf76cb5dd56363e786c7e25ef00fa57296af29a7b2,1444
     pantry-tree:
       size: 271
       sha256: 0db8705011f7f25d9e5f639c52ccce5fccb1de578de685def2b79e289d9de4cc
   original:
-    hackage: store-core-0.4.4.2@sha256:11403cad88cf4f3675d49baf76cb5dd56363e786c7e25ef00fa57296af29a7b2,1444
+    hackage: store-core-0.4.4.2
+- completed:
+    hackage: store-streaming-0.2.0.0@sha256:f1194a9276362691f2ccc92473f4ebc9e7f7e57131e8f7c20c7c2e4eb264eb70,2006
+    pantry-tree:
+      size: 479
+      sha256: 1a9236fe7b9d3172197c57d5b879dd15c51b4f825fd788688eafda75074c7ecc
+  original:
+    hackage: store-streaming-0.2.0.0
 - completed:
     hackage: th-utilities-0.2.3.1@sha256:40ebb0bc9569b4ff5c3be93c58a1e2a35e308a7e3effc73f6b324980f53f73fc,1869
     pantry-tree:
       size: 881
       sha256: fa8f7a729bb497831a087af6368cc44a52bfdf058c54882a6f5513feb4d36212
   original:
-    hackage: th-utilities-0.2.3.1@sha256:40ebb0bc9569b4ff5c3be93c58a1e2a35e308a7e3effc73f6b324980f53f73fc,1869
+    hackage: th-utilities-0.2.3.1
 snapshots:
 - completed:
     size: 489011

--- a/striot-gui.cabal
+++ b/striot-gui.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d594df0084bfe6fa5131a7316755fe54d623f3d0ca9496986c6ef49f093b64b8
+-- hash: af7717a8bf07d6a1b099ca73d20ef1f8a3a95e15af4cf20810966502f9c930c2
 
 name:           striot-gui
 version:        0.1.0.0
@@ -69,7 +69,7 @@ test-suite striot-gui-test
     , algebraic-graphs >=0.1
     , base >=4.9
     , bytestring >=0.9.2
-    , hspec >=2.7.1
+    , hspec >=2.6.1
     , striot >=0.1.0.4
     , striot-gui
   default-language: Haskell2010

--- a/striot-gui.cabal
+++ b/striot-gui.cabal
@@ -4,17 +4,17 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8892e2bbd4c344acb97f1b09b5ac0b9f76555a7eb42f7ba5faab42e064013492
+-- hash: d594df0084bfe6fa5131a7316755fe54d623f3d0ca9496986c6ef49f093b64b8
 
 name:           striot-gui
 version:        0.1.0.0
 description:    Please see the README on GitHub at <https://github.com/jonnyspruce/striot-gui#readme>
-homepage:       https://github.com/jonnyspruce/striot-gui#readme
-bug-reports:    https://github.com/jonnyspruce/striot-gui/issues
+homepage:       https://github.com/JonnySpruce/striot-gui#readme
+bug-reports:    https://github.com/JonnySpruce/striot-gui/issues
 author:         Jonny Spruce
 maintainer:     jspruce94@gmail.com
 copyright:      2020 Jonny Spruce
-license:        BSD3
+license:        Apache
 license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
@@ -23,7 +23,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: https://github.com/jonnyspruce/striot-gui
+  location: https://github.com/JonnySpruce/striot-gui
 
 library
   exposed-modules:
@@ -35,9 +35,8 @@ library
   build-depends:
       aeson >=1.4.6.0
     , algebraic-graphs >=0.1
-    , base >=4.7 && <5
-    , bytestring >=0.10.10.0
-    , containers
+    , base >=4.9
+    , bytestring >=0.9.2
     , striot >=0.1.0.4
   default-language: Haskell2010
 
@@ -51,10 +50,9 @@ executable striot-gui-exe
   build-depends:
       aeson >=1.4.6.0
     , algebraic-graphs >=0.1
-    , base >=4.7 && <5
-    , bytestring >=0.10.10.0
+    , base >=4.9
+    , bytestring >=0.9.2
     , striot >=0.1.0.4
-    , containers
     , striot-gui
   default-language: Haskell2010
 
@@ -69,10 +67,9 @@ test-suite striot-gui-test
   build-depends:
       aeson >=1.4.6.0
     , algebraic-graphs >=0.1
-    , base >=4.7 && <5
-    , bytestring >=0.10.10.0
+    , base >=4.9
+    , bytestring >=0.9.2
+    , hspec >=2.7.1
     , striot >=0.1.0.4
     , striot-gui
-    , hspec
-    , QuickCheck
   default-language: Haskell2010

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,7 +1,6 @@
 {- HLINT ignore "Redundant do" -}
 
 import           Test.Hspec
-import           Test.QuickCheck
 import           Control.Exception              ( evaluate )
 import           Striot.CompileIoT
 import           Striot.StreamGraph


### PR DESCRIPTION
Change resolver, match package versions with StrIoT, and reintroduce `package.yaml`

~~This was unfortunately not as successful as I had hoped, since using resolver `lts-13.25` (same as StrIoT) led to an impossible situation where the `network` package was required at both `<2.9` AND `>3.1` - therefore with no compatible overlap. @jmtd @adam-cattermole - I don't know if there is anything I can do to resolve this and  still use `lts-13.25`?~~

Changes resolver to `lts-13.25` and changes all package versions to match the StrIoT versions. 

As part of this PR I also:
- updated the licence to Apache.
- tidied up the `stack.yaml` and reintroduced the `package.yaml` to help with the building of the `.cabal` file.
