### PR TITLE
Add support for Sink node

### DIFF
--- a/src/NRNode.hs
+++ b/src/NRNode.hs
@@ -88,4 +88,4 @@ getInputType xs n = case inputs of
 
 
 striotTypes :: [String]
-striotTypes = ["filter", "generic-input"]
+striotTypes = ["filter", "generic-input", "sink"]

--- a/src/ToStreamGraph.hs
+++ b/src/ToStreamGraph.hs
@@ -37,6 +37,7 @@ toVertex :: NRNode -> StreamVertex
 toVertex n = case nodeType n of
   "filter"        -> toVertex' n Filter [fromMaybe "" (func n), "s"]
   "generic-input" -> toVertex' n Source [fromMaybe "" (func n)]
+  "sink"          -> toVertex' n Sink [fromMaybe "" (func n)]
 
 -- | converts a node to a specific StreamVertex to be used by StrIoT
 toVertex' :: NRNode -> StreamOperator -> [String] -> StreamVertex

--- a/test/NRNodeSpec.hs
+++ b/test/NRNodeSpec.hs
@@ -48,6 +48,21 @@ spec = do
           nodesFromJSON "test/files/single-node/generic-input.json"
             `shouldReturn` [expectedNode]
 
+      describe "(sink node)" $ do
+        it "correctly reads the data about the node" $ do
+          let expectedNode = NRNode
+                "6be7f1eb.edafc"
+                (Just 1)
+                "sink"
+                (Just "mapM_ $ putStrLn . (\"receiving \"++) . show . value")
+                Nothing
+                (Just "IO ()")
+                (Just [])
+                (Just [])
+
+          nodesFromJSON "test/files/single-node/sink.json"
+            `shouldReturn` [expectedNode]
+
     describe "on multiple nodes" $ do
       it
           "correctly reads data about each node and discards the unnecessary nodes"
@@ -56,38 +71,46 @@ spec = do
             let
               expectedNodes =
                 [ NRNode
-                  "53d73312.aa3aec"
+                  "5f773d75.f7a804"
                   (Just 1) -- while there is another node first, it is a tab node so not relevant
                   "generic-input"
                   (Just
-                    "do\n    threadDelay (1000*1000)\n    return \"Hello World!\""
+                    "do\n    i <- getStdRandom (randomR (1,10)) :: IO Int\n    let s = show i in do\n        threadDelay 1000000\n        putStrLn $ \"client sending \" ++ s\n        return s"
                   )
                   Nothing
                   (Just "String")
-                  (Just [["e2841e3f.0d379"]])
+                  (Just [["f196f84d.7140e8"]])
                   (Just [[2]]) -- The ID above is for the second StrIoT node in the file
-                , NRNode "e2841e3f.0d379"
+                , NRNode "f196f84d.7140e8"
                          (Just 2)
                          "filter"
                          (Just "(\\i -> (read i :: Int) > 5)")
                          (Just "String")
                          (Just "String")
-                         (Just [["fad96b10.65b4a8"]])
+                         (Just [["6be7f1eb.edafc"]])
                          (Just [[3]])
+                , NRNode
+                  "6be7f1eb.edafc"
+                  (Just 3)
+                  "sink"
+                  (Just "mapM_ $ putStrLn . (\"receiving \"++) . show . value")
+                  (Just "String")
+                  (Just "IO ()")
+                  (Just [])
+                  (Just [])
                 ]
 
             n <- nodesFromJSON "test/files/multiple-node-types.json"
             -- check that all nodes have been added
             length n `shouldBe` 3
 
-            let actualNodes = take 2 n
+            let actualNodes = take 3 n
             actualNodes `shouldBe` expectedNodes
 
       it
           "correctly determines the input types based on the previous node's output type"
         $ do
             nodes <- nodesFromJSON "test/files/complex-connections.json"
-            print nodes
             let (n1 : n2 : _) = nodes
 
             input n1 `shouldBe` Nothing

--- a/test/files/multiple-node-types.json
+++ b/test/files/multiple-node-types.json
@@ -1,43 +1,41 @@
 [{
-    "id": "750cd9a7.1e9928",
+    "id": "23598ab3.6b1e16",
     "type": "tab",
     "label": "Flow 1",
     "disabled": false,
     "info": ""
 }, {
-    "id": "53d73312.aa3aec",
+    "id": "5f773d75.f7a804",
     "type": "generic-input",
-    "z": "750cd9a7.1e9928",
-    "name": "",
-    "func": "do\n    threadDelay (1000*1000)\n    return \"Hello World!\"",
+    "z": "23598ab3.6b1e16",
+    "name": "Random number generator",
+    "func": "do\n    i <- getStdRandom (randomR (1,10)) :: IO Int\n    let s = show i in do\n        threadDelay 1000000\n        putStrLn $ \"client sending \" ++ s\n        return s",
     "output": "String",
-    "x": 160,
-    "y": 280,
+    "x": 150,
+    "y": 380,
     "wires": [
-        ["e2841e3f.0d379"]
+        ["f196f84d.7140e8"]
     ]
 }, {
-    "id": "e2841e3f.0d379",
+    "id": "f196f84d.7140e8",
     "type": "filter",
-    "z": "750cd9a7.1e9928",
+    "z": "23598ab3.6b1e16",
     "name": "",
     "func": "(\\i -> (read i :: Int) > 5)",
     "output": "String",
-    "x": 400,
-    "y": 280,
+    "x": 350,
+    "y": 380,
     "wires": [
-        ["fad96b10.65b4a8"]
+        ["6be7f1eb.edafc"]
     ]
 }, {
-    "id": "fad96b10.65b4a8",
-    "type": "filter",
-    "z": "750cd9a7.1e9928",
+    "id": "6be7f1eb.edafc",
+    "type": "sink",
+    "z": "23598ab3.6b1e16",
     "name": "",
-    "func": "(\\i -> (read i :: Int) < 8)",
-    "output": "String",
-    "x": 550,
-    "y": 280,
-    "wires": [
-        []
-    ]
+    "func": "mapM_ $ putStrLn . (\"receiving \"++) . show . value",
+    "output": "IO ()",
+    "x": 490,
+    "y": 380,
+    "wires": []
 }]

--- a/test/files/single-node/sink.json
+++ b/test/files/single-node/sink.json
@@ -1,0 +1,11 @@
+[{
+    "id": "6be7f1eb.edafc",
+    "type": "sink",
+    "z": "23598ab3.6b1e16",
+    "name": "",
+    "func": "mapM_ $ putStrLn . (\"receiving \"++) . show . value",
+    "output": "IO ()",
+    "x": 490,
+    "y": 380,
+    "wires": []
+}]


### PR DESCRIPTION
This adds the final node needed for the minimum viable nodes to run with StrIoT. I have tested and confirmed this can be passed into StrIoT with this. More work needs to be done to automatically be able to do this however - see https://github.com/JonnySpruce/striot-gui/issues/8.

Also updates tests.

Resolves https://github.com/JonnySpruce/striot-gui/issues/13