### PR TITLE
Add generation-options node

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,8 @@ dependencies:
   - algebraic-graphs >=0.1
   - base >= 4.9
   - bytestring >= 0.9.2
+  - split >= 0.2.3.4
+  - text >= 1.2.3.1
   - striot >=0.1.0.4
 
 library:

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,7 @@ extra-deps:
   - network-3.1.0.0
   - prometheus-2.1.2
   - socks-0.6.1
+  - split-0.2.3.4
   - store-streaming-0.1.0.0
   - th-utilities-0.2.3.1
   - time-compat-1.9.2.2

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -68,6 +68,13 @@ packages:
   original:
     hackage: socks-0.6.1
 - completed:
+    hackage: split-0.2.3.4@sha256:bad9bfc9e8e0aca4ac1f7b3a2767ee6b1c199d4a1b6960db5cc3d7674aee5d73,2564
+    pantry-tree:
+      size: 439
+      sha256: d931baa404f6867a23ed342c11ef27613227a7a82ba2324f95da184fffad0bd9
+  original:
+    hackage: split-0.2.3.4
+- completed:
     hackage: store-streaming-0.1.0.0@sha256:39d2c8b7960a90195c5f10e60334d1b10324aad01b3470fd8713b7acfdbf9cab,2009
     pantry-tree:
       size: 478

--- a/striot-gui.cabal
+++ b/striot-gui.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: beeb5fd969c79a4a2f1762da80b741a5efe2dbbc81a11ab5da1e809cf8cbb138
+-- hash: 36761cafd7640d1c76d78949b718e261dd26de6f5f1931862b8b1bcaa7b0f6f7
 
 name:           striot-gui
 version:        0.1.0.0
@@ -38,7 +38,9 @@ library
     , algebraic-graphs >=0.1
     , base >=4.9
     , bytestring >=0.9.2
+    , split >=0.2.3.4
     , striot >=0.1.0.4
+    , text >=1.2.3.1
   default-language: Haskell2010
 
 executable striot-gui-exe
@@ -53,8 +55,10 @@ executable striot-gui-exe
     , algebraic-graphs >=0.1
     , base >=4.9
     , bytestring >=0.9.2
+    , split >=0.2.3.4
     , striot >=0.1.0.4
     , striot-gui
+    , text >=1.2.3.1
   default-language: Haskell2010
 
 test-suite striot-gui-test
@@ -73,6 +77,8 @@ test-suite striot-gui-test
     , base >=4.9
     , bytestring >=0.9.2
     , hspec >=2.6.1
+    , split >=0.2.3.4
     , striot >=0.1.0.4
     , striot-gui
+    , text >=1.2.3.1
   default-language: Haskell2010

--- a/test/ToStreamGraphSpec.hs
+++ b/test/ToStreamGraphSpec.hs
@@ -26,6 +26,9 @@ spec = do
                      (Just "String")
                      (Just [[]])
                      (Just [[]])
+                     Nothing
+                     Nothing
+                     Nothing
             ]
       let graph = toStreamGraph nodes
 
@@ -44,6 +47,9 @@ spec = do
                      (Just "Int")
                      (Just [["node2"]])
                      (Just [[2]])
+                     Nothing
+                     Nothing
+                     Nothing
             , NRNode "node2"
                      (Just 2)
                      "filter"
@@ -52,6 +58,9 @@ spec = do
                      (Just "String")
                      (Just [["node1"]])
                      (Just [[1]])
+                     Nothing
+                     Nothing
+                     Nothing
             ]
 
       let graph    = toStreamGraph nodes
@@ -91,3 +100,12 @@ spec = do
         let expectedAdjacency =
               [(v1, [v2]), (v2, [v3]), (v3, []), (v4, [v5]), (v5, [])]
         adjacencyList graph `shouldBe` expectedAdjacency
+
+    describe "with generation-options node" $ do
+      it "should not be included in the created StreamGraph" $ do
+        nodes <- nodesFromJSON "test/files/multiple-node-types.json"
+        let graph = toStreamGraph nodes
+
+        -- check the counts are as expected (i.e. generation-settings node not included)
+        vertexCount graph `shouldBe` 3
+        edgeCount graph `shouldBe` 2

--- a/test/files/multiple-node-types.json
+++ b/test/files/multiple-node-types.json
@@ -5,6 +5,18 @@
     "disabled": false,
     "info": ""
 }, {
+    "id": "4b18bbc2.dcad64",
+    "type": "generation-options",
+    "z": "9465397e.467d38",
+    "name": "",
+    "func": "-- code goes here",
+    "imports": "Striot.FunctionalIoTtypes, Striot.FunctionalProcessing, Striot.Nodes",
+    "packages": "random, example",
+    "optimise": true,
+    "x": 240,
+    "y": 180,
+    "wires": []
+}, {
     "id": "5f773d75.f7a804",
     "type": "generic-input",
     "z": "23598ab3.6b1e16",

--- a/test/files/single-node/generation-options.json
+++ b/test/files/single-node/generation-options.json
@@ -1,0 +1,13 @@
+[{
+    "id": "4b18bbc2.dcad64",
+    "type": "generation-options",
+    "z": "9465397e.467d38",
+    "name": "",
+    "func": "-- code goes here",
+    "imports": "Striot.FunctionalIoTtypes, Striot.FunctionalProcessing, Striot.Nodes",
+    "packages": "random, example",
+    "optimise": true,
+    "x": 240,
+    "y": 180,
+    "wires": []
+}]


### PR DESCRIPTION
Resolves https://github.com/JonnySpruce/striot-gui/issues/6

Adds support for the generation-options node, which is the equivalent of the `GenerateOpts` type in StrIoT. This work exposes a function which converts the node into a `GenerateOpts` object so that it can then be passed to StrIoT. 